### PR TITLE
Amend main.go 

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,6 @@ func run(ctx context.Context, db *sql.DB) error {
 
 func main() {
 	// TODO: Open connection to your PostgreSQL database
-	//assuming you are going name your database instance db like so: db, err := sql.Open("postgres", pgConString)
+	//assuming you are going to name your database instance db like so: db, err := sql.Open("postgres", pgConString)
 	run(context.Background(), db)
 }

--- a/main.go
+++ b/main.go
@@ -35,5 +35,6 @@ func run(ctx context.Context, db *sql.DB) error {
 
 func main() {
 	// TODO: Open connection to your PostgreSQL database
-	run(context.Background(), nil)
+	//assuming you are going name your database instance db like so: db, err := sql.Open("postgres", pgConString)
+	run(context.Background(), db)
 }


### PR DESCRIPTION
Following the sqlc-tour example , run(context.Background(), nil) yielded a "Invalid memory address or nil pointer dereference" because the db pointer reflects as nil instead of db